### PR TITLE
Allow to specify query operator

### DIFF
--- a/lib/solr/query/request.rb
+++ b/lib/solr/query/request.rb
@@ -19,7 +19,7 @@ module Solr
     class Request
       attr_reader :search_term
       attr_accessor :filters, :fields, :facets, :boosting, :debug_mode, :spellcheck,
-                    :limit_docs_by_field, :phrase_slop, :response_fields
+                    :limit_docs_by_field, :phrase_slop, :response_fields, :query_operator
       attr_writer :grouping, :sorting
 
       def initialize(search_term:, fields: [], filters: [])

--- a/lib/solr/query/request/edismax_adapter.rb
+++ b/lib/solr/query/request/edismax_adapter.rb
@@ -13,6 +13,7 @@ module Solr
         EDISMAX_PHRASE_SLOP = :ps
         RESPONSE_FIELDS = :fl
         RERANK_QUERY = :rq
+        QUERY_OPERATOR = :'q.op'
 
         attr_reader :request
 
@@ -33,6 +34,7 @@ module Solr
           solr_params = add_spellcheck(solr_params)
           solr_params = add_rerank_query(solr_params)
           solr_params = add_phrase_slop(solr_params)
+          solr_params = add_query_operator(solr_params)
           solr_params
         end
 
@@ -149,6 +151,11 @@ module Solr
         def add_phrase_slop(solr_params)
           return solr_params unless request.phrase_slop
           solr_params.merge(EDISMAX_PHRASE_SLOP => request.phrase_slop)
+        end
+
+        def add_query_operator(solr_params)
+          return solr_params unless request.query_operator
+          solr_params.merge(QUERY_OPERATOR => request.query_operator)
         end
       end
     end

--- a/spec/query/edismax_adapter_spec.rb
+++ b/spec/query/edismax_adapter_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe Solr::Query::Request::EdismaxAdapter do
       request.grouping = grouping
       request.sorting = sorting
       request.phrase_slop = 5
+      request.query_operator = :AND
       request
     end
 
@@ -94,6 +95,7 @@ RSpec.describe Solr::Query::Request::EdismaxAdapter do
         pf: ['field_2^4'],
         ps: 5,
         q: 'Search Term',
+        'q.op': :AND,
         qf: ['field_1^1', 'field_2^16'],
         sort: ['exists(field_1) desc, field_1 asc', 'exists(field_2) desc, field_2 desc']
       }


### PR DESCRIPTION
https://lucene.apache.org/solr/guide/7_1/the-standard-query-parser.html#standard-query-parser-parameters
This param is required to specify "AND" match instead of "OR" (default).