### PR TITLE
Fix solr range filter formatter

### DIFF
--- a/lib/solr/query/request/filter.rb
+++ b/lib/solr/query/request/filter.rb
@@ -42,11 +42,11 @@ module Solr
         end
 
         def to_interval_solr_value(range)
-          solr_min = to_primitive_solr_value(range.min)
-          solr_max = if date_infinity?(range.max) || range.max.to_f.infinite?
+          solr_min = to_primitive_solr_value(range.first)
+          solr_max = if date_infinity?(range.last) || range.last.to_f.infinite?
                        '*'
                      else
-                       to_primitive_solr_value(range.max)
+                       to_primitive_solr_value(range.last)
                      end
           "[#{solr_min} TO #{solr_max}]"
         end


### PR DESCRIPTION
For descending ranges (for example 100..1) `range.min` and `range.max` return `nil` causing `to_interval_solr_value` to return an empty range filter `"[\"\" TO \"\"]"`.
 This PR fix it by taking the `first` and `last` range element to create the solr filter string.