### PR TITLE
[instrumentation-fixes] make instrumentation occur

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Installation: `gem install solrb`
     * [Dictionary boosting function](#dictionary-boosting-function)
   * [Field list](#field-list)
 * [Deleting documents](#deleting-documents)
+* [Active Support instrumentation](#active-support-instrumentation)
 * [Running specs](#running-specs)
 
 
@@ -286,6 +287,24 @@ Solr.delete_by_id(3242343, commit: true)
 Solr.delete_by_query('*:*')
 Solr.delete_by_query('*:*', commit: true)
 ```
+
+# Active Support instrumentation
+
+This gem publishes events via [Active Support Instrumentation](https://edgeguides.rubyonrails.org/active_support_instrumentation.html)
+
+To subscribe to solrb events, you can add this code to initializer:
+
+```ruby
+ActiveSupport::Notifications.subscribe('request.solrb')  do |*args|
+  event = ActiveSupport::Notifications::Event.new(*args)
+  if Logger::INFO == Rails.logger.level
+    Rails.logger.info("Solrb #{event.duration.round(1)}ms")
+  elsif Logger::DEBUG == Rails.logger.level && Rails.env.development?
+    Pry::ColorPrinter.pp(event.payload)
+  end
+end
+```
+
 
 
 # Running specs

--- a/lib/solr/connection.rb
+++ b/lib/solr/connection.rb
@@ -1,7 +1,7 @@
 module Solr
   # low-level connection that can do network requests to Solr
   class Connection
-    INSTRUMENT_KEY = 'solrb.request'.freeze
+    INSTRUMENT_KEY = 'request.solrb'.freeze
 
     def initialize(url, faraday_options: Solr.configuration.faraday_options)
       # Allow mock the connection for testing

--- a/lib/solr/query/request/runner.rb
+++ b/lib/solr/query/request/runner.rb
@@ -22,10 +22,7 @@ module Solr
 
         def run
           raw_response = connection(PATH).post_as_json(request_params)
-          response = Solr::Response.from_raw_response(raw_response)
-          Solr.instrument(name: 'solrb.request_response_cycle',
-                          data: { request: request_params, response: raw_response })
-          response
+          Solr::Response.from_raw_response(raw_response)
         end
 
         private

--- a/lib/solr/version.rb
+++ b/lib/solr/version.rb
@@ -1,3 +1,3 @@
 module Solr
-  VERSION = '0.1.4'.freeze
+  VERSION = '0.1.5'.freeze
 end


### PR DESCRIPTION
only once per request and use naming convention suggested by Rails guides.
https://edgeguides.rubyonrails.org/active_support_instrumentation.html#creating-custom-events

> You should follow Rails conventions when defining your own events. The format is: event.library.