### PR TITLE
Filter “infinite to finite” ranges

### DIFF
--- a/lib/solr/query/request/filter.rb
+++ b/lib/solr/query/request/filter.rb
@@ -48,7 +48,7 @@ module Solr
         end
 
         def to_primitive_solr_value(value)
-          if date_infinity?(value) || value.to_f.infinite?
+          if date_infinity?(value) || numeric_infinity?(value)
             '*'
           elsif date_or_time?(value)
             value.strftime('%Y-%m-%dT%H:%M:%SZ')
@@ -59,6 +59,10 @@ module Solr
 
         def date_infinity?(value)
           value.is_a?(DateTime::Infinity)
+        end
+
+        def numeric_infinity?(value)
+          value.is_a?(Numeric) && value.infinite?
         end
 
         def date_or_time?(value)

--- a/lib/solr/query/request/filter.rb
+++ b/lib/solr/query/request/filter.rb
@@ -38,21 +38,19 @@ module Solr
         private
 
         def solr_prefix
-          '-' if NOT_EQUAL_TYPE == @type
+          '-' if NOT_EQUAL_TYPE == type
         end
 
         def to_interval_solr_value(range)
           solr_min = to_primitive_solr_value(range.first)
-          solr_max = if date_infinity?(range.last) || range.last.to_f.infinite?
-                       '*'
-                     else
-                       to_primitive_solr_value(range.last)
-                     end
+          solr_max = to_primitive_solr_value(range.last)
           "[#{solr_min} TO #{solr_max}]"
         end
 
         def to_primitive_solr_value(value)
-          if date_or_time?(value)
+          if date_infinity?(value) || value.to_f.infinite?
+            '*'
+          elsif date_or_time?(value)
             value.strftime('%Y-%m-%dT%H:%M:%SZ')
           else
             %("#{value.to_s.solr_escape}")

--- a/spec/query/request/filter_spec.rb
+++ b/spec/query/request/filter_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe Solr::Query::Request::Filter do
         subject { described_class.new(type: :equal, field: :field, value: 1..Float::INFINITY).to_solr_s }
         it { is_expected.to eq('field:(["1" TO *])') }
       end
+
+      context 'when min is infinity' do
+        subject { described_class.new(type: :equal, field: :field, value: -Float::INFINITY..1).to_solr_s }
+        it { is_expected.to eq('field:([* TO "1"])') }
+      end
     end
 
     context 'when value is date' do


### PR DESCRIPTION
Adds an ability to filter from infinite value to some finite value:
```ruby
fl=expires_at_dp:[* TO 2018-12-23T12:16:48Z]
```