### PR TITLE
Verbose Connection failed error

### DIFF
--- a/lib/solr/errors/solr_connection_failed_error.rb
+++ b/lib/solr/errors/solr_connection_failed_error.rb
@@ -1,10 +1,11 @@
 module Solr
   module Errors
     class SolrConnectionFailedError < StandardError
-      def initialize(solr_urls)
+      def initialize(solr_url_errors)
+        urls_message = solr_url_errors.map { |url, error| "#{url} - #{error}" }.join("\n")
         message = <<~MESSAGE
           Could not connect to any available solr instance:
-          #{solr_urls.join(', ')}
+          #{urls_message}
         MESSAGE
         super(message)
       end

--- a/lib/solr/errors/solr_connection_failed_error.rb
+++ b/lib/solr/errors/solr_connection_failed_error.rb
@@ -2,7 +2,7 @@ module Solr
   module Errors
     class SolrConnectionFailedError < StandardError
       def initialize(solr_url_errors)
-        urls_message = solr_url_errors.map { |url, error| "#{url} - #{error}" }.join("\n")
+        urls_message = solr_url_errors.map { |url, error| "[#{url}] #{error}" }.join("\n")
         message = <<~MESSAGE
           Could not connect to any available solr instance:
           #{urls_message}

--- a/lib/solr/request/runner.rb
+++ b/lib/solr/request/runner.rb
@@ -28,6 +28,7 @@ module Solr
       end
 
       def call
+        solr_url_errors = {}
         solr_urls.each do |node_url|
           request_url = build_request_url(url: node_url,
                                           path: request.path,
@@ -38,11 +39,12 @@ module Solr
             raise Solr::Errors::SolrQueryError, solr_response.error_message unless solr_response.ok?
             return solr_response
           rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Errno::EADDRNOTAVAIL => e
+            solr_url_errors[node_url] = e.message
             # Try next node
           end
         end
 
-        raise Solr::Errors::SolrConnectionFailedError.new(solr_urls)
+        raise Solr::Errors::SolrConnectionFailedError.new(solr_url_errors)
       end
 
       private

--- a/lib/solr/request/runner.rb
+++ b/lib/solr/request/runner.rb
@@ -39,7 +39,7 @@ module Solr
             raise Solr::Errors::SolrQueryError, solr_response.error_message unless solr_response.ok?
             return solr_response
           rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Errno::EADDRNOTAVAIL => e
-            solr_url_errors[node_url] = e.message
+            solr_url_errors[node_url] = "#{e.class.name} - #{e.message}"
             # Try next node
           end
         end

--- a/lib/solr/version.rb
+++ b/lib/solr/version.rb
@@ -1,3 +1,3 @@
 module Solr
-  VERSION = '0.2.3'.freeze
+  VERSION = '0.2.4'.freeze
 end


### PR DESCRIPTION
Example:
```
Solr::Errors::SolrConnectionFailedError: Could not connect to any available solr instance:
http://0.0.0.0:1/solr/en - Failed to open TCP connection to 0.0.0.0:1 (Connection refused - connect(2) for "0.0.0.0" port 1)
http://0.0.0.0:2/solr/en - Failed to open TCP connection to 0.0.0.0:2 (Connection refused - connect(2) for "0.0.0.0" port 2)
```