### PR TITLE
Don’t raise an error if response body is empty

### DIFF
--- a/lib/solr/response/parser.rb
+++ b/lib/solr/response/parser.rb
@@ -12,7 +12,7 @@ module Solr
       def call
         # 404 is a special case, it didn't hit Solr (more likely than not)
         return not_found_response if @raw_response.status == 404
-        parsed_body = JSON.parse(@raw_response.body).freeze
+        parsed_body = @raw_response.body ? JSON.parse(@raw_response.body).freeze : {}
         http_status = parse_http_status
         header = parse_header(parsed_body)
         solr_error = parse_solr_error(parsed_body)


### PR DESCRIPTION
I'm not sure which http status code have responses with the empty body, but this PR fixes a `NoMethodError`:
```
NoMethodError: undefined method `[]' for nil:NilClass
1 File "/app/vendor/bundle/ruby/2.5.0/bundler/gems/solrb-71c87ca2e0e8/lib/solr/response/parser.rb" line 34 in parse_header
2 File "/app/vendor/bundle/ruby/2.5.0/bundler/gems/solrb-71c87ca2e0e8/lib/solr/response/parser.rb" line 17 in call
3 File "/app/vendor/bundle/ruby/2.5.0/bundler/gems/solrb-71c87ca2e0e8/lib/solr/response/parser.rb" line 5 in call
4 File "/app/vendor/bundle/ruby/2.5.0/bundler/gems/solrb-71c87ca2e0e8/lib/solr/request/runner.rb" line 39 in block in call