### PR TITLE
Allow to use custom SOLR_URL in specs

### DIFF
--- a/lib/solr/configuration.rb
+++ b/lib/solr/configuration.rb
@@ -73,14 +73,7 @@ module Solr
     end
 
     def core_name_from_solr_url_env
-      full_solr_core_uri = URI.parse(ENV['SOLR_URL'])
-      core_name = full_solr_core_uri.path.gsub('/solr', '').delete('/')
-
-      if !core_name || core_name == ''
-        raise Solr::Errors::CouldNotInferImplicitCoreName
-      end
-
-      core_name
+      Solr::Support::UrlHelper.core_name_from_url(ENV['SOLR_URL'])
     end
 
     def build_env_url_core_config(name: nil)

--- a/lib/solr/errors/could_not_detect_endpoint_in_url.rb
+++ b/lib/solr/errors/could_not_detect_endpoint_in_url.rb
@@ -1,0 +1,14 @@
+module Solr
+  module Errors
+    class CouldNotDetectEndpointInUrl < StandardError
+      MESSAGE = '
+        TODO: Add message
+
+      '.freeze
+
+      def initialize
+        super(MESSAGE)
+      end
+    end
+  end
+end

--- a/lib/solr/support/url_helper.rb
+++ b/lib/solr/support/url_helper.rb
@@ -33,6 +33,27 @@ module Solr
       def current_core
         Solr.current_core_config
       end
+
+      def core_name_from_url(url)
+        full_solr_core_uri = URI.parse(url)
+        core_name = full_solr_core_uri.path.gsub('/solr', '').delete('/')
+
+        if !core_name || core_name == ''
+          raise Solr::Errors::CouldNotInferImplicitCoreName
+        end
+
+        core_name
+      end
+
+      def solr_endpoint_from_url(url)
+        solr_endpoint = url[/(\A.+\/solr)/]
+
+        if !solr_endpoint || solr_endpoint == ''
+          raise Solr::Errors::CouldNotDetectEndpointInUrl
+        end
+
+        solr_endpoint
+      end
     end
   end
 end

--- a/spec/indexing/indexing_spec.rb
+++ b/spec/indexing/indexing_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Solr::Indexing do
       context 'without default core' do
         before do
           Solr.configure do |config|
-            config.url = 'http://localhost:8983/solr'
+            config.url = Solr::Support::UrlHelper.solr_endpoint_from_url(ENV['SOLR_URL'])
 
             config.define_core(name: :'test-core') do |f|
               f.field :name, dynamic_field: :txt_en
@@ -72,7 +72,7 @@ RSpec.describe Solr::Indexing do
       context 'with default core' do
         before do
           Solr.configure do |config|
-            config.url = 'http://localhost:8983/solr'
+            config.url = Solr::Support::UrlHelper.solr_endpoint_from_url(ENV['SOLR_URL'])
 
             config.define_core(name: :'test-core', default: true) do |f|
               f.field :name, dynamic_field: :txt_en

--- a/spec/request/runner_spec.rb
+++ b/spec/request/runner_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Solr::Request::Runner do
 
   describe '.call' do
     it 'calls solr connection' do
-      expect(solr_connection).to receive(:call).with(url: 'http://localhost:8983/solr/test-core/select',
+      expect(solr_connection).to receive(:call).with(url: "#{ENV['SOLR_URL']}/select",
                                                      method: :get,
                                                      body: '{ "some_json_key": "some_json_value" }')
       subject.call


### PR DESCRIPTION
Before the change, SOLR_URL had to be `http://localhost:8983/solr/test-core` to pass tests.